### PR TITLE
Add Astillero environment manifest and agent conventions

### DIFF
--- a/.astillero/environment.json
+++ b/.astillero/environment.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "container": {
+    "dockerfile": [
+      "FROM node:22-bookworm"
+    ],
+    "workdir": "/workspace/www.vntotxt",
+    "env": {
+      "CYPRESS_INSTALL_BINARY": "0",
+      "PUBLIC_VNTOTXT_API": "http://localhost:3000",
+      "PUBLIC_PAYPAL_CLIENT_ID": "test",
+      "PUBLIC_PAYPAL_PRO_PLAN_ID": "P-TEST"
+    }
+  },
+  "setup": "npm ci --no-audit --no-fund",
+  "gates": {
+    "typecheck": "npx astro check",
+    "build": "npx astro build"
+  }
+}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,155 @@
+# ARCHITECTURE.md
+
+What exists and why. For how to change it, read `CONTRIBUTING.md`.
+
+## What this system does
+
+`vntotxt.com` is the marketing site for Vntotxt, a WhatsApp bot that turns voice
+notes into text. It is a fully static Astro site: a landing page (hero, how it
+works, features, pricing), a Free-plan and a Pro-plan checkout page, a
+thank-you page, a privacy policy, a 404, and one Spanish blog post. Every page
+exists in English and in Spanish. The only runtime behaviour is browser
+JavaScript on the checkout pages, which talks to the Vntotxt API
+(`PUBLIC_VNTOTXT_API`, the sibling `api.vntotext` repo) to verify a WhatsApp
+number and, for Pro, to confirm a PayPal subscription. Netlify builds `main`
+with `npm run build` and serves `dist/` (`netlify.toml`).
+
+## Directory map
+
+| Path | What belongs here | What does not |
+|---|---|---|
+| `src/pages/` | One `.astro` file per English route (`index`, `vntotxt-free`, `vntotxt-pro`, `subscription-success`, `privacy-policy`, `404`) plus the generated endpoints `favicon.ico.ts`, `manifest.json.ts`, `robots.txt.ts`. | Markup shared by two pages; that goes in `src/components/`. |
+| `src/pages/es/` | The Spanish sibling of each page. Same file name, same structure, `language="es"`. | A page that has no English sibling. |
+| `src/pages/posts/` | Blog posts as `.mdx` with frontmatter (`layout`, `title`, `pubDate`, `description`), rendered by `MarkdownPostLayout`. Only Spanish posts exist today. | Anything that is not a post. |
+| `src/layouts/` | `Layout.astro` (the `<html>` shell: SEO head, fonts, analytics, sitemap link), `NavigationLayout.astro` (Layout + Navbar + Footer), `MarkdownPostLayout.astro` (article shell for posts). | Page content. |
+| `src/components/` | Reusable `.astro` components: cards, forms, phone mock-up, bubbles, navbar, footer. `common/` holds the head-only pieces (`HeadSeo`, `HeadAssets`, `Analytics`). | Client-side logic (see `src/scripts/`). |
+| `src/i18n/` | `ui.ts`: the `en`/`es` string table keyed by dotted ids. `utils.ts`: `getLangFromUrl` and `useTranslations`. | Anything else; there is no routing logic here, routing is by directory. |
+| `src/scripts/` | `form-utils.js`, the checkout flow: WhatsApp verification, PayPal confirmation, geo-IP lookup. Loaded by the form components via `<script src>`. Plain JS, attaches functions to `window`. | Astro components. |
+| `src/styles/main.css` | Tailwind directives, the Ubuntu `@font-face` rules, and two keyframe animations. | Component styles; use Tailwind/daisyUI classes inline. |
+| `src/env.d.ts` | Types for the three `PUBLIC_*` env vars. Add a line here when you add a variable. | Runtime code. |
+| `public/` | Static assets copied verbatim: logos, illustration SVGs, `fonts/`, `images/posts/`. Astro's `<Image>` also imports from here for optimisation. | Generated files. |
+| `cypress/` | Smoke specs (`e2e/vntotxtWeb/Smoke/`) and two configs; `prod.config.ts` points at `https://vntotxt.com/`, `qa.config.ts` is empty. | Unit tests; there are none. |
+| `.astillero/` | The Astillero agent environment manifest (`environment.json`). | Anything a human runs. |
+| `netlify.toml` | `publish = "dist"` and a list of force-200 redirects. | Build commands; Netlify uses the package script. |
+| `dist/`, `.astro/`, `node_modules/` | Build output, generated types, dependencies. All gitignored. | Committed content. |
+
+## Stack
+
+- **Astro 4.5**, static output (no adapter, no SSR). `astro.config.mjs` sets
+  `site: "https://vntotxt.com"`, the `i18n` block, and integrations.
+- **Tailwind 3 + daisyUI 4** through `@astrojs/tailwind` with
+  `applyBaseStyles: false` (the base layer is in `src/styles/main.css`).
+  `tailwind.config.mjs` defines the `default` daisyUI theme (primary
+  `#1C5F5F`, secondary `#E0F1DF`, accent `#C2FA6B`) and the `font-ubuntu`
+  family. `@tailwindcss/typography` gives the `prose` classes used on the
+  privacy policy and posts.
+- **`@astrojs/mdx`** for posts, **`@astrojs/sitemap`** (emits
+  `sitemap-index.xml`), **`@astrojs/partytown`** (runs the Google Analytics
+  tag off the main thread; `forward: ["dataLayer.push"]`), **`astro-seo`**
+  for the `<head>` meta.
+- **`sharp` / `sharp-ico`** generate `favicon.ico` at build time from
+  `public/logo.png`.
+- **boxicons** for icons (CSS import in `Layout.astro`, `<i class="bx ...">`).
+- **TypeScript** with `astro/tsconfigs/strict`; `astro check` is the type
+  gate. There is no ESLint or Prettier config; formatting is Prettier's
+  default as the Astro VS Code extension applies it.
+- **Cypress 13** for smoke tests against a deployed URL. It is a regular
+  dependency, so `npm ci` would download the ~200 MB binary; the agent
+  container sets `CYPRESS_INSTALL_BINARY=0` to skip that.
+- **Node**: there is no `.nvmrc` or `engines` field. The agent container runs
+  Node 22 (`node:22-bookworm`) and the build passes there.
+
+> TODO(human): confirm which Node version Netlify builds with, and pin it in a
+> `.nvmrc` so local, Netlify and the agent container agree.
+
+## Key flows
+
+**A page renders.** `src/pages/es/vntotxt-pro.astro` → `Layout.astro`
+(`language="es"`, `title`) → `HeadSeo` builds title/description/OpenGraph from
+`Astro.props` with `t("page.title")` defaults, `HeadAssets` preloads the Ubuntu
+fonts and the intl-tel-input stylesheet, `Analytics` injects gtag via
+Partytown. Every component that shows text does
+`const lang = getLangFromUrl(Astro.url); const t = useTranslations(lang);` and
+renders `{t("some.key")}`. `getLangFromUrl` reads the first path segment, so a
+page under `src/pages/es/` gets Spanish strings and everything else English.
+
+**Free plan signup.** `/vntotxt-free` → `FormFreeSubscription.astro` →
+`form-utils.js`: `sendVerificationCodeProcess(API, tierId=1, lang)` POSTs
+`{waId, tierId, lang}` to `${API}/v1/request-subscription`; the user types
+the code WhatsApp sent them; `verificationCodeProcess(API, redirect=true,
+lang)` POSTs to `${API}/v1/verify-request` and redirects to
+`/subscription-success/?subscriptionId=...` (with `/es` prefix when
+`lang == "es"`).
+
+**Pro plan checkout.** `/vntotxt-pro` → `FormSubscription.astro` with
+`tierId={2}` and `paypalPlanId={PUBLIC_PAYPAL_PRO_PLAN_ID}`. Same two
+verification calls, but `redirect=false`; the form then reveals the PayPal
+Buttons (SDK loaded from `paypal.com/sdk/js?client-id=...&vault=true&intent=subscription`).
+`onApprove` calls `confirmPurchase(API, data)` → POST `${API}/v1/confirm-purchase`
+→ redirect to `/subscription-success/?orderID=...&subscriptionID=...`.
+`subscription-success.astro` shows `CardOrderDetails`, which reads those query
+params in a `<script>` and fills the table.
+
+**A build.** `npm run build` = `astro check && astro build`. `astro check`
+type-checks `.astro` and `.ts` files; `astro build` prerenders 11 pages,
+runs the three endpoint files, optimises every imported image into
+`dist/_astro/`, and writes the sitemap. Netlify runs the same command.
+
+## Data model
+
+There is no data. State lives in the URL (`?subscriptionId`, `?orderID`,
+`?subscriptionID`) and in the Vntotxt API. Configuration is three build-time
+variables, all `PUBLIC_*` so Astro inlines them into the client bundle:
+`PUBLIC_VNTOTXT_API`, `PUBLIC_PAYPAL_CLIENT_ID`, `PUBLIC_PAYPAL_PRO_PLAN_ID`
+(`.env.example`). Netlify holds the real values; the agent container gets
+placeholders.
+
+## Boundaries and rules
+
+- Pages compose layouts and components; components never import pages.
+- All user-visible text comes from `src/i18n/ui.ts`. Both `en` and `es`
+  tables have 77 keys and must stay key-for-key identical (`useTranslations`
+  falls back to English for a missing Spanish key, silently).
+- Locale is expressed twice: the directory (`src/pages/es/`) decides which
+  strings render, and the `language` prop on `Layout` is passed explicitly.
+  Keep them consistent.
+- Network calls happen only in `src/scripts/form-utils.js`, only to
+  `PUBLIC_VNTOTXT_API`, `ipinfo.io` (geo-IP for the phone input) and PayPal.
+  Components pass the API base in via `define:vars`; they never fetch.
+- External scripts and styles are loaded from CDNs by URL (`intl-tel-input`
+  17.0.8 on cdnjs, PayPal SDK, gtag). Do not vendor them.
+- The WhatsApp bot number (`17867444726`) and the contact number are hard-coded
+  in `index.astro`, `es/index.astro`, `Footer.astro`, `subscription-success.astro`,
+  `404.astro` and `cypress/fixtures/vntotxt.json`. Change all of them together.
+
+## Known debt
+
+- **i18n config vs. file layout.** `astro.config.mjs` sets
+  `prefixDefaultLocale: true` and `redirectToDefaultLocale: true`, which
+  expects English pages under `src/pages/en/`, but they live at the root.
+  The force-200 redirects in `netlify.toml` and the `<meta http-equiv="refresh">`
+  in `Layout.astro` exist to fight the resulting redirects. That meta tag
+  evaluates to `content="en/"` because of operator precedence
+  (`"0;url=/" + language == "en"`), so it is effectively inert. Do not "fix"
+  either without a task that covers the whole routing story.
+  > TODO(human): decide whether the intended layout is root = English (then
+  > drop `prefixDefaultLocale`/`redirectToDefaultLocale`) or `/en/` (then move
+  > the pages).
+- **`vite.define: { 'process.env': process.env }`** in `astro.config.mjs`
+  inlines the entire build-time environment into any client module that
+  references `process.env`. Nothing in `src/` does today, so nothing leaks,
+  but any new client script using `process.env.X` would ship the build
+  machine's environment to browsers. Use `import.meta.env.PUBLIC_*` instead.
+  > TODO(human): this define looks unused; consider removing it.
+- `cypress/qa.config.ts` is empty, so the `cypress-qa*` scripts fail, and
+  `cypress/support/commands.ts` is the untouched template.
+- `404.astro` and `privacy-policy.astro` have no `es/` sibling and carry
+  hard-coded English copy instead of i18n keys; `404.astro` also imports
+  `CardOrderDetails` without using it.
+- Duplicate pages: `src/pages/X.astro` and `src/pages/es/X.astro` are
+  near-identical copies (300 lines each for the home page). Any change must be
+  made twice.
+- The `posts` layout links to `/tags/...` routes that do not exist, and its
+  frontmatter `image`/`tags` values are the Astro template defaults.
+- The `ipinfo.io` token in `form-utils.js` is committed in the client bundle
+  by design (it is a public browser token).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# CONTRIBUTING.md
+
+Instructions for changing this codebase. Read `ARCHITECTURE.md` first for
+what exists and why; this file does not repeat it.
+
+## Setup
+
+You need Node 22 or newer and npm. No database, no services.
+
+```bash
+npm ci
+cp .env.example .env     # only needed to exercise the checkout forms locally
+npm run dev              # http://localhost:4321
+```
+
+Inside an Astillero agent container this is already done: Node 22 is on
+`PATH`, `npm ci` has run (with `CYPRESS_INSTALL_BINARY=0`, so there is no
+Cypress binary), and the three `PUBLIC_*` variables hold placeholders. Do not
+run Docker there.
+
+## Commands
+
+| Task | Command |
+|---|---|
+| Typecheck | `npx astro check` |
+| Build | `npx astro build` |
+| Both, as Netlify runs them | `npm run build` |
+| Dev server | `npm run dev` |
+| Preview a build | `npm run preview` |
+| Smoke tests against production | `npm run cypress-prod-smoke-headless` (needs the Cypress binary and a browser; not available in the agent container) |
+
+## Definition of done
+
+- Every acceptance criterion of the task is met.
+- `npx astro check` reports 0 errors. Do not add warnings or hints in files
+  you touched.
+- `npx astro build` completes.
+- Every new user-facing string is a key in `src/i18n/ui.ts` with both an
+  `en` and an `es` value, rendered through `t("key")`.
+- A change to a page or layout is mirrored in its `src/pages/es/` sibling
+  (or the root sibling, if you started in `es/`) in the same commit.
+- If you changed an element id that a Cypress spec selects (`#hero-section`,
+  `#phone-section`, `#how-it-works-link`, `#how-it-works-mobile-link`,
+  `.dropdown`), the spec under `cypress/e2e/` is updated in the same commit.
+- A new environment variable is added to `.env.example`, typed in
+  `src/env.d.ts`, and given a placeholder in `.astillero/environment.json`.
+- Nothing from `dist/`, `.astro/`, `node_modules/`, `.env`,
+  `.env.production` or `cypress/screenshots/` is committed.
+- Changes are on the task branch. Never on `main`.
+
+## Code conventions
+
+- **Components are `.astro` files** with a frontmatter block, a `Props`
+  interface, and a destructure with defaults:
+  `const { showButton = false } = Astro.props;` (`CardProSubscription.astro`).
+- **Text goes through i18n.** At the top of any component that renders text:
+  `const lang = getLangFromUrl(Astro.url); const t = useTranslations(lang);`
+  then `{t("home.mainTitle.1")}`. Keys are dotted, lower camel, grouped by
+  screen (`home.`, `nav.`, `footer.`, `plan.`, `checkout.`, `thankyou.`,
+  `order.`). Inline `<strong>` in a value is allowed and rendered with
+  `set:html` where the component expects it.
+- **Locale-aware links** use the `lang == "es" ? "/es" : "/"` pattern from
+  `Navbar.astro`; there is no helper. Spanish routes are `/es/<same-path>`.
+- **Styling is utility classes** (Tailwind + daisyUI: `btn btn-primary`,
+  `card`, `navbar`, `alert alert-error`). No `<style>` blocks, no new CSS
+  files; `src/styles/main.css` only holds fonts, base layers and keyframes.
+  Headings use `font-ubuntu`.
+- **Images** are imported from `public/` and rendered with Astro's `<Image>`
+  (`import Logo from "../../public/logo_transparent_540.png"`) so they are
+  optimised; plain `<img>` only inside MDX posts.
+- **Client-side code** lives in `src/scripts/form-utils.js` as `window.*`
+  functions, wired from a `<script type="module" define:vars={{ ... }}>` in the
+  component (`FormSubscription.astro`). Keep it plain JS; there is no bundler
+  config for TypeScript there. Show feedback by toggling the `.alert-info` /
+  `.alert-error` elements, never with `alert()`.
+- **Endpoints** (`src/pages/*.ts`) export `GET: APIRoute` and return a
+  `Response`; they run at build time only.
+- **Language**: code, comments and commit messages in English; site copy in
+  both languages. Comments are rare and explain why.
+- **Formatting**: Prettier defaults (2 spaces, double quotes); `FormSubscription.astro`
+  and `FormFreeSubscription.astro` use 4 spaces. Match the file you are in.
+
+## Testing
+
+There are no unit tests and no test runner. The gates are `astro check` and
+`astro build`, and the reviewer checks acceptance criteria by reading the
+diff and, where it helps, the built HTML under `dist/`.
+
+- For a behaviour you can only see in a browser, describe in your result what
+  you rendered and what you observed (`npm run preview` serves `dist/` on
+  port 4321).
+- Cypress specs in `cypress/e2e/vntotxtWeb/Smoke/` run only against a deployed
+  URL (`cypress/prod.config.ts`). Keep them in sync with element ids; do not
+  try to run them in the agent container.
+
+## Git workflow
+
+- Default branch `main`, which Netlify builds and serves. There is no CI and
+  no branch protection; the Astillero board opens a PR per task and the
+  Product Owner merges it.
+- Branch names are short and lowercase (`stcomp`, `chore/astillero-onboarding`).
+- Commit subjects are one line, imperative, stating the behaviour: "Add
+  sitemap", "Fix subscription success to 404 bug". No trailing period, no
+  "wip".
+- One commit per logical change.
+
+## Do not
+
+- Do not commit to `main`, and never push from an agent run.
+- Do not hard-code visible text; add an i18n key with both languages.
+- Do not change one locale's page without changing the other.
+- Do not add a dependency without naming it, and why, in your result summary.
+- Do not touch `astro.config.mjs`'s `i18n` block, `netlify.toml`, or the
+  `<meta http-equiv="refresh">` in `Layout.astro` unless the task is about
+  routing; see Known debt in `ARCHITECTURE.md`.
+- Do not use `process.env` in anything that ships to the browser; use
+  `import.meta.env.PUBLIC_*`.
+- Do not change the WhatsApp numbers, PayPal plan ids, or the Google Analytics
+  id unless the task says so, and then change every copy.
+- Do not commit `dist/`, `.astro/`, `.env`, or Cypress screenshots.
+- Do not install the Cypress binary in the agent container.
+
+## When unsure
+
+Stop and report rather than invent. Put the question and the two options you
+saw in your result summary (or the PR description). Cases that count: a
+string whose Spanish translation you cannot confirm, a tier id or PayPal plan
+whose meaning you cannot verify, a change that would alter the routing or
+redirect behaviour, or a Cypress selector you are not sure is still used.


### PR DESCRIPTION
## Summary
- `.astillero/environment.json`: the agent container for this repo. `node:22-bookworm`, `npm ci` with `CYPRESS_INSTALL_BINARY=0` (the Cypress binary is not needed for the gates), placeholder values for the three `PUBLIC_*` variables, gates `typecheck` = `npx astro check` and `build` = `npx astro build` (together, exactly `npm run build`).
- `ARCHITECTURE.md` and `CONTRIBUTING.md`: written from the code as it is today, following Astillero's BOOTSTRAP process. Every claim was checked against the repo; the places where only the owner can decide are marked `TODO(human)`:
  - Node version to pin in a `.nvmrc` (the container uses 22, the build passes there).
  - The i18n config (`prefixDefaultLocale`/`redirectToDefaultLocale`) versus English pages at the root, and the `netlify.toml` redirects plus the inert `<meta http-equiv="refresh">` that work around it.
  - `vite.define: {'process.env': process.env}` in `astro.config.mjs`, which would inline the build environment into any client script that references `process.env` (none does today).

No source file changes. Please read the two docs as a review of my understanding of the repo and correct anything wrong before merging; agents will treat every line as true.

## Verification
- `npm ci && npm run build` on a clean clone in `node:22-bookworm`: 11 pages built, exit 0.
- Astillero `env check --gates` on this manifest inside a sandbox: image built, setup 24s, typecheck ok, build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnhhi7e5cjbU3oF8bJRR82