### PR TITLE
Fix subscription checkout bugs

### DIFF
--- a/src/components/FormSubscription.astro
+++ b/src/components/FormSubscription.astro
@@ -161,16 +161,16 @@ const PAYPAL_PRO_PLAN_ID = import.meta.env.PUBLIC_PAYPAL_PRO_PLAN_ID;
             },
             createSubscription: function (data, actions) {
                 return actions.subscription.create({
-                    /* Creates the subscription */
-                    // plan_id: "P-0PC67333FG471260VMY42XTY", // PROD
-                    plan_id: PAYPAL_PRO_PLAN_ID, // TEST
+                    plan_id: PAYPAL_PRO_PLAN_ID,
+                    // Lets the backend correlate PayPal webhooks with this request
+                    custom_id: String(subscriptionRequestIdInput.value),
                 });
             },
             onApprove: function (data, actions) {
                 // alert(data.subscriptionID); // You can add optional success message for the subscriber here
-                confirmPurchase(VNTOTXT_API, data)
+                return confirmPurchase(VNTOTXT_API, data)
                     .then(() => console.log("Purchase confirmed"))
-                    .error(console.error);
+                    .catch(console.error);
             },
         })
         // .render("#paypal-button-container-P-0PC67333FG471260VMY42XTY"); // Renders the PayPal button

--- a/src/scripts/form-utils.js
+++ b/src/scripts/form-utils.js
@@ -70,9 +70,11 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
   if (phoneInput.isValidNumber()) {
     const phoneNumber = phoneInput.getNumber();
     const waId = phoneNumber.replace("+", "");
+    const submitButton = getSubmitButton(event);
 
     loadingSendVerificationCode.style.display = "";
     phoneInputField.disabled = true;
+    if (submitButton) submitButton.disabled = true;
 
     try {
       let response = await fetch(vntotxtApi + "/v1/request-subscription", {
@@ -108,11 +110,11 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
       phoneInputField.disabled = false;
       error.style.display = "";
       errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
-      loadingSendVerificationCode.style.display = "none";
       console.error(e);
+    } finally {
+      loadingSendVerificationCode.style.display = "none";
+      if (submitButton) submitButton.disabled = false;
     }
-
-    loadingSendVerificationCode.style.display = "none";
   } else {
     error.style.display = "";
     errorText.innerHTML = `Invalid phone number.`;
@@ -127,10 +129,13 @@ window.verificationCodeProcess = async function (vntotxtApi, redirectToSuccess, 
   ).value;
   const subscriptionRequestId = subscriptionRequestIdInput.value;
 
+  const submitButton = getSubmitButton(event);
+
   info.style.display = "none";
   error.style.display = "none";
 
   loadingVerification.style.display = "";
+  if (submitButton) submitButton.disabled = true;
 
   try {
     let response = await fetch(vntotxtApi + "/v1/verify-request", {
@@ -164,10 +169,12 @@ window.verificationCodeProcess = async function (vntotxtApi, redirectToSuccess, 
         if (paypalDiv)
           paypalDiv.style.display = "";
 
-        subscriptionRequestIdInput.value = data.subscriptionRequestId;
+        // Keep the id from request-subscription unless the API echoes a new one
+        if (data && data.subscriptionRequestId)
+          subscriptionRequestIdInput.value = data.subscriptionRequestId;
 
         if (redirectToSuccess)
-          window.location.href = `${lang == "es" ? "/es" : ""}/subscription-success/?subscriptionId=${data.subscriptionId}`;
+          window.location.href = `${lang == "es" ? "/es" : ""}/subscription-success/?subscriptionID=${data.subscriptionId}`;
       } else {
         error.style.display = "";
         errorText.innerHTML = message;
@@ -179,11 +186,11 @@ window.verificationCodeProcess = async function (vntotxtApi, redirectToSuccess, 
   } catch (e) {
     error.style.display = "";
     errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
-    loadingVerification.style.display = "none";
     console.error(e);
+  } finally {
+    loadingVerification.style.display = "none";
+    if (submitButton) submitButton.disabled = false;
   }
-
-  loadingVerification.style.display = "none";
 }
 
 window.confirmPurchase = async function (vntotxtApi, paypalSubscription) {
@@ -222,6 +229,11 @@ window.confirmPurchase = async function (vntotxtApi, paypalSubscription) {
     loadingVerification.style.display = "none";
     console.error(e);
   }
+}
+
+window.getSubmitButton = function (event) {
+  const form = event && event.target;
+  return form && form.querySelector ? form.querySelector('button[type="submit"]') : null;
 }
 
 window.getIp = function (callback) {


### PR DESCRIPTION
## Summary
- Pass the verified subscription request id as `custom_id` when creating the PayPal subscription. The backend confirm-purchase now verifies the PayPal subscription and rejects it unless `custom_id` matches, so this must be live before that backend version deploys.
- Return the confirmPurchase promise from `onApprove` and use `.catch`; the old `.error` threw a TypeError on every approval.
- Redirect free subscribers with `subscriptionID`, the parameter the order details card reads, so the success page shows the subscription number.
- Disable the submit button while request-subscription and verify-request are in flight and re-enable it in `finally`, which prevents duplicate PINs from a double click.
- Only replace the stored request id when the API returns one.

## Test plan
- [x] `npx astro check` and `npx astro build` pass with 0 errors
- [ ] Sandbox PRO checkout: PayPal dashboard shows the request id as custom_id and the success page shows order and subscription ids
- [ ] Free checkout: success page shows the subscription number
- [ ] Double-click "Send verification code": only one PIN arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsWj7yYuuS7VrS3fRZD4G