### PR TITLE
Localize the checkout error messages

### DIFF
--- a/src/components/FormFreeSubscription.astro
+++ b/src/components/FormFreeSubscription.astro
@@ -3,6 +3,10 @@ import { getLangFromUrl, useTranslations } from "../i18n/utils";
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
+
+const phoneValidationError = t("checkout.verification.error.phoneValidation");
+const invalidPhoneNumber = t("checkout.verification.error.invalidPhone");
+
 const VNTOTXT_API = import.meta.env.PUBLIC_VNTOTXT_API;
 ---
 
@@ -105,8 +109,16 @@ const VNTOTXT_API = import.meta.env.PUBLIC_VNTOTXT_API;
 
 <script src="../scripts/form-utils.js"></script>
 
-<script type="module" define:vars={{ VNTOTXT_API, lang }}>
+<script
+    type="module"
+    define:vars={{ VNTOTXT_API, lang, phoneValidationError, invalidPhoneNumber }}
+>
     window.lang = lang;
+
+    window.i18nMessages = {
+        phoneValidationError,
+        invalidPhoneNumber,
+    };
 
     window.onload = function () {
         // scroll to checkoutVerification

--- a/src/components/FormSubscription.astro
+++ b/src/components/FormSubscription.astro
@@ -11,6 +11,12 @@ interface Props {
 
 const { paypalPlanId, tierId } = Astro.props;
 
+const phoneValidationError = t("checkout.verification.error.phoneValidation");
+const invalidPhoneNumber = t("checkout.verification.error.invalidPhone");
+const subscriptionValidationError = t(
+    "checkout.verification.error.subscriptionValidation",
+);
+
 const VNTOTXT_API = import.meta.env.PUBLIC_VNTOTXT_API;
 const PAYPAL_CLIENT_ID = import.meta.env.PUBLIC_PAYPAL_CLIENT_ID;
 const PAYPAL_PRO_PLAN_ID = import.meta.env.PUBLIC_PAYPAL_PRO_PLAN_ID;
@@ -136,9 +142,24 @@ const PAYPAL_PRO_PLAN_ID = import.meta.env.PUBLIC_PAYPAL_PRO_PLAN_ID;
 
 <script
     type="module"
-    define:vars={{ VNTOTXT_API, PAYPAL_CLIENT_ID, PAYPAL_PRO_PLAN_ID, tierId, lang }}
+    define:vars={{
+        VNTOTXT_API,
+        PAYPAL_CLIENT_ID,
+        PAYPAL_PRO_PLAN_ID,
+        tierId,
+        lang,
+        phoneValidationError,
+        invalidPhoneNumber,
+        subscriptionValidationError,
+    }}
 >
     window.lang = lang;
+
+    window.i18nMessages = {
+        phoneValidationError,
+        invalidPhoneNumber,
+        subscriptionValidationError,
+    };
 
     window.onload = function () {
         // scroll to checkoutVerification

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -132,6 +132,11 @@ export const ui = {
     "checkout.verification.verify": "Verify",
     "checkout.verification.subscribe": "Verify and subscribe",
     "checkout.paypal.description": "Please proceed with the PayPal payment",
+    "checkout.verification.error.phoneValidation":
+      "There was an error validating the phone number. Please try again.",
+    "checkout.verification.error.invalidPhone": "Invalid phone number.",
+    "checkout.verification.error.subscriptionValidation":
+      "There was an error validating your subscription. Please try again.",
     // Thank you
     "thankyou.mainTitle": "Subscription Successful!",
     "thankyou.mainDescription":
@@ -278,6 +283,11 @@ export const ui = {
     "checkout.verification.subscribe": "Verificar y suscribirse",
     "checkout.paypal.description":
       "Por favor continúa con el pago a través de PayPal",
+    "checkout.verification.error.phoneValidation":
+      "Hubo un error al validar el número de teléfono. Por favor, inténtalo de nuevo.",
+    "checkout.verification.error.invalidPhone": "Número de teléfono inválido.",
+    "checkout.verification.error.subscriptionValidation":
+      "Hubo un error al validar tu suscripción. Por favor, inténtalo de nuevo.",
     // Thank you
     "thankyou.mainTitle": "¡Suscripción exitosa!",
     "thankyou.mainDescription":

--- a/src/scripts/form-utils.js
+++ b/src/scripts/form-utils.js
@@ -111,12 +111,12 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
       } else {
         phoneInputField.disabled = false;
         error.style.display = "";
-        errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
+        errorText.innerHTML = window.i18nMessages.phoneValidationError;
       }
     } catch (e) {
       phoneInputField.disabled = false;
       error.style.display = "";
-      errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
+      errorText.innerHTML = window.i18nMessages.phoneValidationError;
       console.error(e);
     } finally {
       loadingSendVerificationCode.style.display = "none";
@@ -125,7 +125,7 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
     }
   } else {
     error.style.display = "";
-    errorText.innerHTML = `Invalid phone number.`;
+    errorText.innerHTML = window.i18nMessages.invalidPhoneNumber;
   }
 }
 
@@ -198,11 +198,11 @@ window.verificationCodeProcess = async function (vntotxtApi, redirectToSuccess, 
       }
     } else {
       error.style.display = "";
-      errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
+      errorText.innerHTML = window.i18nMessages.phoneValidationError;
     }
   } catch (e) {
     error.style.display = "";
-    errorText.innerHTML = `There was an error validating the phone number. Please try again.`;
+    errorText.innerHTML = window.i18nMessages.phoneValidationError;
     console.error(e);
   } finally {
     loadingVerification.style.display = "none";
@@ -238,11 +238,11 @@ window.confirmPurchase = async function (vntotxtApi, paypalSubscription) {
       }
     } else {
       error.style.display = "";
-      errorText.innerHTML = `There was an error validating your subscription. Please try again.`;
+      errorText.innerHTML = window.i18nMessages.subscriptionValidationError;
     }
   } catch (e) {
     error.style.display = "";
-    errorText.innerHTML = `There was an error validating your subscription. Please try again.`;
+    errorText.innerHTML = window.i18nMessages.subscriptionValidationError;
     loadingVerification.style.display = "none";
     console.error(e);
   }


### PR DESCRIPTION
src/scripts/form-utils.js is a plain non-module script (loaded via <script src="../scripts/form-utils.js">) with no import access, so it cannot call t() directly. Since FormSubscription.astro and FormFreeSubscription.astro already compute `lang`/`t` in their frontmatter and already pass values into their inline `<script type="module" define:vars={...}>` blocks (which run before the form-utils.js functions are invoked, via window.onload), the translated strings should be produced with t() in each component's frontmatter, passed through define:vars, and exposed as window-scoped globals that form-utils.js reads instead of its three hard-coded English strings. API-provided `message` values (the `errorText.innerHTML = message;` lines) must NOT be touched.

## Acceptance criteria
- [ ] src/i18n/ui.ts gains three new keys with both en and es entries, namespaced under checkout.verification.error.* (exact names at dev's discretion, e.g. checkout.verification.error.phoneValidation, checkout.verification.error.invalidPhone, checkout.verification.error.subscriptionValidation): en values equal the current English strings verbatim ('There was an error validating the phone number. Please try again.', 'Invalid phone number.', 'There was an error validating your subscription. Please try again.'), es values are their Spanish translations.
- [ ] FormSubscription.astro and FormFreeSubscription.astro frontmatter call t() for the phone-validation and invalid-phone-number keys and pass the resulting strings into their existing define:vars script block; FormSubscription.astro additionally passes the subscription-validation string (needed for confirmPurchase, which only FormSubscription.astro invokes — FormFreeSubscription.astro does not need it).
- [ ] Each inline module script assigns the passed-in strings to window-scoped properties (e.g. window.i18nMessages = { phoneValidationError, invalidPhoneNumber, subscriptionValidationError }) before instanceDocComponents()/the form event listeners can fire, so form-utils.js can read them synchronously when an error occurs.
- [ ] form-utils.js no longer contains any hard-coded English error literal; the two occurrences of 'There was an error validating the phone number. Please try again.' in sendVerificationCodeProcess and the two occurrences in verificationCodeProcess all read from the same window-scoped phone-validation-error value; the 'Invalid phone number.' occurrence in sendVerificationCodeProcess reads from the invalid-phone-number value; both occurrences of 'There was an error validating your subscription. Please try again.' in confirmPurchase read from the subscription-validation-error value.
- [ ] All `errorText.innerHTML = message;` lines that display the API response's `message` field are left exactly as-is (no i18n wrapping) — they keep showing whatever the API returns.
- [ ] On /vntotxt-pro and /vntotxt-free (English), the three error paths (network/HTTP failure on send, invalid phone number, network/HTTP failure on purchase confirmation) show the same English text as before the change.
- [ ] On /es/vntotxt-pro and /es/vntotxt-free, the same three error paths show the Spanish text from ui.ts instead of English.
- [ ] No changes to the shape of data sent to the API or to any success-path behavior.

Closes #13

_Opened by astillero for T-13. Validate the criteria against this PR, then `approve T-13` to merge it._