### PR TITLE
Let the user change the phone number after the verification code is sent

### DIFF
--- a/src/components/FormFreeSubscription.astro
+++ b/src/components/FormFreeSubscription.astro
@@ -78,6 +78,14 @@ const VNTOTXT_API = import.meta.env.PUBLIC_VNTOTXT_API;
                 <!-- <span class="label-text-alt">Bottom Right label</span> -->
             </div>
         </label>
+        <div class="flex w-full justify-end">
+            <button
+                id="changeNumberBtn"
+                type="button"
+                class="btn btn-link btn-sm px-0"
+                >{t("checkout.verification.changeNumber")}</button
+            >
+        </div>
         <div class="flex w-full">
             <button type="submit" class="btn btn-primary mt-2 btn-block mx-auto"
                 >{t("checkout.verification.subscribe")}
@@ -117,5 +125,6 @@ const VNTOTXT_API = import.meta.env.PUBLIC_VNTOTXT_API;
         verifyCodeForm.addEventListener("submit", (event) =>
             verificationCodeProcess(VNTOTXT_API, true, lang, event),
         );
+        changeNumberBtn.addEventListener("click", changeNumber);
     };
 </script>

--- a/src/components/FormSubscription.astro
+++ b/src/components/FormSubscription.astro
@@ -98,6 +98,14 @@ const PAYPAL_PRO_PLAN_ID = import.meta.env.PUBLIC_PAYPAL_PRO_PLAN_ID;
                 <!-- <span class="label-text-alt">Bottom Right label</span> -->
             </div>
         </label>
+        <div class="flex w-full justify-end">
+            <button
+                id="changeNumberBtn"
+                type="button"
+                class="btn btn-link btn-sm px-0"
+                >{t("checkout.verification.changeNumber")}</button
+            >
+        </div>
         <div class="flex w-full">
             <button type="submit" class="btn btn-primary mt-2 btn-block mx-auto"
                 >{t("checkout.verification.verify")}
@@ -149,6 +157,7 @@ const PAYPAL_PRO_PLAN_ID = import.meta.env.PUBLIC_PAYPAL_PRO_PLAN_ID;
         verifyCodeForm.addEventListener("submit", (event) =>
             verificationCodeProcess(VNTOTXT_API, false, lang, event),
         );
+        changeNumberBtn.addEventListener("click", changeNumber);
     };
 
     paypal

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -95,6 +95,7 @@ export const ui = {
     "checkout.verification.code": "Verification code",
     "checkout.verification.code.enter":
       "Enter the verification code sent to yout WhatsApp",
+    "checkout.verification.changeNumber": "Change number",
     "checkout.verification.verify": "Verify",
     "checkout.verification.subscribe": "Verify and subscribe",
     "checkout.paypal.description": "Please proceed with the Paypal payment",
@@ -202,6 +203,7 @@ export const ui = {
     "checkout.verification.code": "Código de verificación",
     "checkout.verification.code.enter":
       "Ingresa el código de verificación enviado a tu WhatsApp",
+    "checkout.verification.changeNumber": "Cambiar número",
     "checkout.verification.verify": "Verificar",
     "checkout.verification.subscribe": "Verificar y suscribirse",
     "checkout.paypal.description": "Por favor continúa con el pago a través de Paypal",

--- a/src/scripts/form-utils.js
+++ b/src/scripts/form-utils.js
@@ -8,6 +8,9 @@ window.paymentHeading = null;
 
 window.subscriptionRequestIdInput = null;
 
+window.changeNumberBtn = null;
+window.verificationCodeInput = null;
+
 window.phoneInputField = null;
 window.phoneInput = null;
 
@@ -33,6 +36,9 @@ window.instanceDocComponents = function (paypalPlanId) {
   subscriptionRequestIdInput = document.querySelector(
     "#subscriptionRequestIdInput",
   );
+
+  changeNumberBtn = document.querySelector("#changeNumberBtn");
+  verificationCodeInput = document.querySelector("#verificationCodeInput");
 
   // const paypalDiv = document.querySelector("#paypal-button-container-P-0PC67333FG471260VMY42XTY");
   if (paypalPlanId)
@@ -75,6 +81,7 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
     loadingSendVerificationCode.style.display = "";
     phoneInputField.disabled = true;
     if (submitButton) submitButton.disabled = true;
+    if (changeNumberBtn) changeNumberBtn.disabled = true;
 
     try {
       let response = await fetch(vntotxtApi + "/v1/request-subscription", {
@@ -114,11 +121,21 @@ window.sendVerificationCodeProcess = async function (vntotxtApi, tierId, lang, e
     } finally {
       loadingSendVerificationCode.style.display = "none";
       if (submitButton) submitButton.disabled = false;
+      if (changeNumberBtn) changeNumberBtn.disabled = false;
     }
   } else {
     error.style.display = "";
     errorText.innerHTML = `Invalid phone number.`;
   }
+}
+
+window.changeNumber = function () {
+  divWaVerifyButton.style.display = "";
+  verifyCodeForm.style.display = "none";
+  phoneInputField.disabled = false;
+  verificationCodeInput.value = "";
+  info.style.display = "none";
+  error.style.display = "none";
 }
 
 window.verificationCodeProcess = async function (vntotxtApi, redirectToSuccess, lang, event) {


### PR DESCRIPTION
In FormFreeSubscription.astro and FormSubscription.astro, once sendVerificationCodeProcess (src/scripts/form-utils.js) succeeds, #phone is disabled, #divWaVerifyButton is hidden, and #verifyCodeForm is shown. There is currently no way back to the phone step short of a page reload. Add a 'Change number' text link/button inside #verifyCodeForm, placed between the verification-code helper text (span.label-text-alt under #verificationCodeInput) and the submit button div, in both forms. Clicking it returns the user to the phone step: re-shows #divWaVerifyButton, hides #verifyCodeForm, re-enables #phone, clears #verificationCodeInput, and clears any visible alert-info/alert-error. The user can then edit the number and resubmit #verifyWaForm, which calls sendVerificationCodeProcess again and overwrites #subscriptionRequestIdInput with the new subscriptionRequestId from the latest /v1/request-subscription response — the existing success handler already does this (form-utils.js:98), so verificationCodeProcess and confirmPurchase keep reading the correct, latest id via subscriptionRequestIdInput.value with no changes needed there.

## Acceptance criteria
- [ ] A 'Change number' control (type="button", not type="submit") is added inside #verifyCodeForm in both FormFreeSubscription.astro and FormSubscription.astro, positioned between the code-field helper text and the Verify/Verify-and-subscribe button.
- [ ] Its label uses a new t() key, e.g. checkout.verification.changeNumber, with both an 'en' and 'es' entry added to src/i18n/ui.ts (e.g. en: 'Change number', es: 'Cambiar número').
- [ ] Clicking the control before the phone step is visible: hides #verifyCodeForm, shows #divWaVerifyButton, re-enables #phone (phoneInputField.disabled = false), clears #verificationCodeInput's value, and hides both .alert-info and .alert-error if visible.
- [ ] The phone input retains the previously entered number (via intlTelInput) so the user can edit it rather than retype it from scratch.
- [ ] After clicking 'Change number' and resubmitting #verifyWaForm with a corrected number, a new /v1/request-subscription call is made and, on success, #subscriptionRequestIdInput.value is overwritten with the new subscriptionRequestId (already handled by the existing success branch in sendVerificationCodeProcess).
- [ ] Submitting #verifyCodeForm after this flow (POST /v1/verify-request) sends the subscriptionRequestId from the latest successful request-subscription call, not a stale one from an earlier attempt.
- [ ] The new control and behavior work identically in both FormFreeSubscription.astro (free tier) and FormSubscription.astro (PRO tier), and on both the 'en' and 'es' locale routes.
- [ ] Clicking 'Change number' does not submit either form and does not trigger a network request by itself.
- [ ] While #loadingSendVerificationCode is visible (a send request is in flight), the 'Change number' control does not produce an inconsistent state — e.g. it is disabled or hidden until the in-flight request settles.
- [ ] No existing behavior regresses: the original error paths in sendVerificationCodeProcess (invalid number, non-ok response, thrown exception) still re-enable #phone as before, and the payment/verification-success flow (paypal button, confirmPurchase) is unaffected.

Closes #14

_Opened by astillero for T-14. Validate the criteria against this PR, then `approve T-14` to merge it._