### PR TITLE
Audit paid-plan claims against available functionality

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -28,10 +28,10 @@ Nothing to install and nothing to sign up for: the product lives entirely inside
 ## Capabilities and Constraints
 
 - **Free plan:** 15 minutes of transcription per month, multilanguage, basic support, standard processing speed. Enrolment is automatic on first message to the bot; no verification form is required. The remaining monthly quota is appended to the same message as the transcription.
-- **Pro plan:** US$4.99 per month, 180 minutes per month, 30-day free trial, enhanced processing speed, standard support, remaining quota sent as a separate message, access to the web application to view transcriptions. Purchased through WhatsApp number verification then PayPal on `/vntotxt-pro`.
-- **Premium plan:** unlimited minutes, priority processing, premium support, web application access. Not purchasable yet ("coming soon"); listed for transparency.
+- **Pro plan:** US$4.99 per month, 180 minutes per month, 30-day free trial, standard support, remaining quota sent as a separate message. Purchased through WhatsApp number verification then PayPal on `/vntotxt-pro`.
+- **Premium plan:** unlimited minutes, priority processing, premium support. Not purchasable yet ("coming soon"); listed for transparency.
 - Transcriptions are multilanguage.
-- A web application for viewing transcriptions exists (Pro and Premium). The owner chose not to link it from the site yet; mention it as text only.
+- **Unresolved (T-20, 2026-09-07):** this file previously stated that Pro/Premium get "enhanced"/"priority" processing speed and access to a web application for viewing transcriptions. Neither the marketing site nor the API repo available to that audit contains an implementation of a web app or of differentiated processing speed, so the site copy no longer advertises them. Treat both as owner decisions — either confirm the capability exists elsewhere and restore the copy with evidence, or drop the claim for good. See "Audit: T-20 paid-plan claims" below.
 - The site is fully bilingual (English at `/`, Spanish at `/es/`); every string lives in `src/i18n/ui.ts` and both tables must stay key-for-key identical.
 - Routing debt: the English pages live at the root while the Astro i18n config expects `/en/`; the meta-refresh in `Layout.astro` is inert by accident. Do not change routing outside a task that covers it.
 
@@ -49,6 +49,28 @@ Nothing to install and nothing to sign up for: the product lives entirely inside
 - No usage figures are published. The only proof claim approved for the site is that transcriptions are multilanguage (no language count). Do not invent numbers.
 - No testimonials or user quotes exist; do not invent any.
 - The demo transcript shown in the hero (`featurePhone.transcription` in `ui.ts`) is a fictional example and should be presented as one.
+
+## Audit: T-20 paid-plan claims (2026-09-07)
+
+Every capability the Pro plan advertised on `/vntotxt-pro` and the homepage
+pricing table, checked against this repo (the only one available to this
+audit) and cross-referenced with `ARCHITECTURE.md`'s documented flows:
+
+| Claim | Evidence | Verdict |
+|---|---|---|
+| 180 minutes/month, 30-day trial, $4.99/month | `tierId={2}` checkout flow, `CardSubscription`/`PlanCard` price and minutes props; PayPal plan id is a build-time config value the site already relies on | Verified — preserved unchanged |
+| Remaining quota sent as a separate message | `quotaStyle="separate"` vs. Free's `"same"`, rendered distinctly in `PlanCard.astro`/`CardSubscription.astro` | Verified in frontend behaviour description; matches documented bot flow |
+| Multilanguage transcriptions | Shared across all plans, matches "Transcriptions are multilanguage" above | Verified |
+| Standard/basic customer support tiers | Operational claim, not something the static site or its API calls implement or falsify | Not code-verifiable either way; left unchanged (out of this audit's scope) |
+| Enhanced processing speed (Pro), priority processing speed (Premium) | No code, endpoint, or config in this repo differentiates processing speed by plan | **Unresolved** — claim removed from Pro copy (site + `PlanCard`/`CardSubscription` feature lists); Premium's mention stays only because that plan is explicitly "coming soon" and not sold yet |
+| Web app to browse transcriptions (Pro), web app access (Premium) | No web app route, build target, or link exists anywhere in this repo; `api.vntotxt` was also inspected by the wider investigation and did not establish one either | **Unresolved** — claim removed from Pro copy (site + `PlanCard`/`CardSubscription` feature lists) and from Free's "not included" comparison line, which no longer has anything to contrast against |
+
+Resulting Pro feature list (both languages, unchanged price/quota/trial):
+free trial, 180 minutes/month, quota sent as a separate message, multilanguage
+transcriptions, standard customer support. No new capability was added to
+replace the two removed claims — that is an owner decision, not something
+this audit is authorized to build (no dashboard, no priority queue, no new
+plan or pricing).
 
 ## Product Principles
 

--- a/src/components/CardFreeSubscription.astro
+++ b/src/components/CardFreeSubscription.astro
@@ -35,9 +35,5 @@ const { showButton = false } = Astro.props;
             description: t("plan.feature.processing.standard"),
             included: true,
         },
-        {
-            description: t("plan.feature.webapp"),
-            included: false,
-        },
     ]}
 />

--- a/src/components/CardProSubscription.astro
+++ b/src/components/CardProSubscription.astro
@@ -34,13 +34,5 @@ const { showButton = false } = Astro.props;
             description: t("plan.feature.support.standard"),
             included: true,
         },
-        {
-            description: t("plan.feature.processing.enhanced"),
-            included: true,
-        },
-        {
-            description: t("plan.feature.webapp"),
-            included: true,
-        },
     ]}
 />

--- a/src/components/SubscriptionCardList.astro
+++ b/src/components/SubscriptionCardList.astro
@@ -30,7 +30,6 @@ const prefix = lang == "es" ? "/es" : "";
       { description: t("plan.feature.multilanguage"), included: true },
       { description: t("plan.feature.support.basic"), included: true },
       { description: t("plan.feature.processing.standard"), included: true },
-      { description: t("plan.feature.webapp"), included: false },
     ]}
   />
   <PlanCard
@@ -50,8 +49,6 @@ const prefix = lang == "es" ? "/es" : "";
       { description: t("plan.feature.quota.separated"), included: true },
       { description: t("plan.feature.multilanguage"), included: true },
       { description: t("plan.feature.support.standard"), included: true },
-      { description: t("plan.feature.processing.enhanced"), included: true },
-      { description: t("plan.feature.webapp"), included: true },
     ]}
   />
 </div>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -106,11 +106,8 @@ export const ui = {
     "plan.feature.support.premium": "<strong>Premium</strong> customer support",
     "plan.feature.processing.standard":
       "<strong>Standard</strong> processing speed",
-    "plan.feature.processing.enhanced":
-      "<strong>Enhanced</strong> processing speed",
     "plan.feature.processing.priority":
       "<strong>Priority</strong> processing speed",
-    "plan.feature.webapp": "Web app to browse your transcriptions",
     // Footer
     "footer.bot": "Chat with the bot",
     "footer.support": "Support & contact",
@@ -256,11 +253,8 @@ export const ui = {
     "plan.feature.support.premium": "Soporte <strong>premium</strong>",
     "plan.feature.processing.standard":
       "Velocidad de procesamiento <strong>estándar</strong>",
-    "plan.feature.processing.enhanced":
-      "Velocidad de procesamiento <strong>mejorada</strong>",
     "plan.feature.processing.priority":
       "Velocidad de procesamiento <strong>prioritaria</strong>",
-    "plan.feature.webapp": "Aplicación web para ver tus transcripciones",
     // Footer
     "footer.bot": "Chatea con el bot",
     "footer.support": "Soporte y contacto",


### PR DESCRIPTION
Owner-approved backlog scope from the VNTOTXT business investigation. Local code findings are not confirmed production incidents: inspect the current implementation and existing completed tasks before changing it. Deliver only the scoped change in a reviewable branch. Do not deploy, change prices, modify production data, initiate real payments, contact customers, or start/restart/stop the application server without separate explicit owner authorization. Follow repository conventions and configured validation gates. Use synthetic data for verification; do not retrieve private transcripts or phone numbers for analysis.

Sources: src/components/CardProSubscription.astro, src/i18n/ui.ts and the English/Spanish Pro pages advertise web-app access and enhanced processing speed. The inspected API/marketing repositories did not establish those capabilities; they may exist elsewhere. Audit claims against demonstrable functionality and correct unsupported copy consistently. This is not authorization to build a dashboard, priority queue, new plan, or new pricing. Preserve the existing price, quota and trial terms. Existing website tasks T-13 and T-14 cover localized checkout errors and changing phone number; do not duplicate them.

## Acceptance criteria
- [ ] Document each paid-plan capability claim with implementation or reproducible evidence, marking capabilities that cannot be verified as unresolved rather than assuming they exist.
- [ ] English and Spanish plan/checkout copy describe only verified available functionality; unsupported capability promises are removed or corrected consistently, with the resulting copy included for review.
- [ ] The existing $4.99 price, 180-minute allowance, 30-day trial and checkout navigation remain unchanged; verify both language pages with the configured website checks.
- [ ] Missing capabilities are listed as owner decisions, not implemented as new features under this copy audit.

Closes #20

_Opened by astillero for T-20. Validate the criteria against this PR, then `approve T-20` to merge it._